### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 name: Rust builds
 
+permissions:
+  contents: read
 on: push
 
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/Raphdf201/minigrep/security/code-scanning/1](https://github.com/Raphdf201/minigrep/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow to restrict `GITHUB_TOKEN` permissions to the minimum needed. In this workflow, none of the jobs requires write access to repository contents; only read access is needed to check out the code and allow actions to access repository files. You should add `permissions: contents: read` at either the workflow root (affecting all jobs) or, for finer control, within each job (for this workflow, root-level is simplest and best). You only need to insert the following block just after (or before) the `on:` key at the top:

```yaml
permissions:
  contents: read
```

No further changes, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
